### PR TITLE
Prevent passing in the Shopify API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Set these properties within `cloak: { shopify: { ... } }` in the nuxt.config.js:
 - `url` - Your public Shopify store URL, for example: https://brand.myshopify.com or https://shop.brand.com.  Defaults to `process.env.SHOPIFY_URL`.
 - `storefront:`
   - `token` - The Storefront API token of your custom app.  Defaults to `process.env.SHOPIFY_STOREFRONT_TOKEN`.
-  - `version` - The [Storefront API version](https://shopify.dev/api/usage/versioning) to use.  Defaults to `2022-04`.
-  - `language` - A Storefront API recognized [LanguageCode](https://shopify.dev/api/storefront/2022-04/enums/LanguageCode).  Defaults to the 1st part of `process.env.CMS_SITE` if it is ISO-like (ex: if `en_US` or `en-US` then `EN`).
-  - `country` - A Storefront API recognized [CountryCode](https://shopify.dev/api/storefront/2022-04/enums/CountryCode).  Defaults to the 2nd part of `process.env.CMS_SITE` if it is ISO-like (ex: if `en_US` or `en-US` then `US`).
+  - `language` - A Storefront API recognized [LanguageCode](https://shopify.dev/api/storefront/2022-07/enums/LanguageCode).  Defaults to the 1st part of `process.env.CMS_SITE` if it is ISO-like (ex: if `en_US` or `en-US` then `EN`).
+  - `country` - A Storefront API recognized [CountryCode](https://shopify.dev/api/storefront/2022-07/enums/CountryCode).  Defaults to the 2nd part of `process.env.CMS_SITE` if it is ISO-like (ex: if `en_US` or `en-US` then `US`).
   - `injectClient` - Boolean for whether to inject the `$storefront` client globally.  Defaults to `true`.  You would set this to `false` when this module is a depedency of another module (like [@cloak-app/algolia](https://github.com/BKWLD/cloak-algolia)) that is creating `$storefront` a different way.
 - `mocks` - An array of objects for use with [`mockAxiosGql`](https://github.com/BKWLD/cloak-utils/blob/main/src/axios.js).
 
@@ -53,7 +52,6 @@ import mergeClientHelpers from '@cloak-app/shopify/factories/merge-helpers'
 const storefront = mergeClientHelpers(makeStorefrontClient({
   url: process.env.SHOPIFY_URL,
   token: process.env.SHOPIFY_STOREFRONT_TOKEN,
-  version: '2022-04', // Optional
 }))
 
 // Optional, inject it globally into Vue components

--- a/factories/storefront-client-factory.js
+++ b/factories/storefront-client-factory.js
@@ -5,14 +5,13 @@ import isPlainObject from 'lodash/isPlainObject'
 export default function (axios, {
 	url,
 	token,
-	version = '2022-04',
 	language,
 	country,
 } = {}) {
 
 	// Make Storefront instance
 	const storefront = axios.create({
-		baseURL: `${url}/api/${version}/graphql`,
+		baseURL: `${url}/api/2022-07/graphql`,
 		headers: {
 			'Accept': 'application/json',
 			'Content-Type': 'application/json',

--- a/helpers/formatting.js
+++ b/helpers/formatting.js
@@ -10,7 +10,7 @@ export function getShopifyId(id) {
 	if (String(id).match(/^\d+$/)) return id
 
 	// De-base64.  This should only be required when migrating cart ids that were
-	// stored in a cookie, AKA client-side pre Storefront API version 2022-04.
+	// stored in a cookie, AKA client-side pre Storefront API version 2022-07.
 	if (!id.match(/^gid:\/\//)) id = atob(id)
 
 	// Return the ID

--- a/nuxt.js
+++ b/nuxt.js
@@ -16,7 +16,6 @@ export default function() {
 		url: process.env.SHOPIFY_URL,
 		storefront: {
 			token: process.env.SHOPIFY_STOREFRONT_TOKEN,
-			version: '2022-04',
 			language,
 			country,
 			injectClient: true,


### PR DESCRIPTION
The API version affects how GQL queries are formed.  Since GQL fragments are owned by this repo, there is a hard coupling of the API version to the fragments and it could cause confision if the API version was updated externally and that breaks this package’s GQL fragments.